### PR TITLE
change elm-test dependency to lower case

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -10,7 +10,7 @@
     "dependencies": {
       "elm-lang/core": "2.0.0 <= v < 3.0.0",
       "maxsnew/IO": "1.0.0 <= v < 2.0.0",
-      "deadfoxygrandpa/Elm-Test": "1.0.0 <= v < 2.0.0",
+      "deadfoxygrandpa/elm-test": "1.0.0 <= v < 2.0.0",
       "TheSeamau5/elm-check": "3.0.0 <= v < 4.0.0",
       "TheSeamau5/elm-shrink": "2.0.0 <= v < 3.0.0",
       "TheSeamau5/elm-random-extra": "2.1.0 <= v < 3.0.0"


### PR DESCRIPTION
elm package output an error when tries to install Elm-Test, but when changed to elm-test everything works as expected.
