### PR TITLE
remove backTicks for 0.18

### DIFF
--- a/src/Base64.elm
+++ b/src/Base64.elm
@@ -76,18 +76,19 @@ toCharList bitList =
             Array.fromList base64CharsList
 
         toBase64Char index =
-            Maybe.withDefault '!' (Array.get index array)
+            Array.get index array
+            |> Maybe.withDefault '!'
 
         toChars ( a, b, c ) =
             case ( a, b, c ) of
                 ( a, -1, -1 ) ->
-                    (dropLast 2 (List.map toBase64Char (partitionBits [ a, 0, 0 ]))) `append` [ '=', '=' ]
+                    append (dropLast 2 (List.map toBase64Char (partitionBits [ a, 0, 0 ]))) [ '=', '=' ]
 
                 ( a, b, -1 ) ->
-                    (dropLast 1 (List.map toBase64Char (partitionBits [ a, b, 0 ]))) `append` [ '=' ]
+                    append (dropLast 1 (List.map toBase64Char (partitionBits [ a, b, 0 ]))) [ '=' ]
 
                 ( a, b, c ) ->
-                    (List.map toBase64Char (partitionBits [ a, b, c ]))
+                    List.map toBase64Char (partitionBits [ a, b, c ])
     in
         List.concatMap toChars bitList
 

--- a/src/BitList.elm
+++ b/src/BitList.elm
@@ -13,9 +13,9 @@ fromNumber int =
     if int == 0 then
         []
     else if int % 2 == 1 then
-        fromNumber (int // 2) `append` [ On ]
+        append (fromNumber <| int // 2) [ On ]
     else
-        fromNumber (int // 2) `append` [ Off ]
+        append (fromNumber <| int // 2) [ Off ]
 
 
 fromNumberWithSize : Int -> Int -> List Bit
@@ -27,7 +27,7 @@ fromNumberWithSize number size =
         paddingSize =
             size - length bitList
     in
-        repeat paddingSize Off `append` bitList
+        append (repeat paddingSize Off) bitList
 
 
 fromByte : Int -> List Bit


### PR DESCRIPTION
Looking at https://github.com/elm-lang/elm-platform/blob/master/upgrade-docs/0.18.md you have small changes needed for 0.18. (Up to you if you want to release the changes now with 0.17 - I would presume not)
