### PR TITLE
Rewrite BitList.partition to be tail recursive

### DIFF
--- a/src/BitList.elm
+++ b/src/BitList.elm
@@ -58,4 +58,13 @@ partition size list =
     if length list <= size then
         [ list ]
     else
-        take size list :: partition size (drop size list)
+        let
+            partitionTail size list res =
+                case list of
+                    [] ->
+                        res
+
+                    _ ->
+                        partitionTail size (drop size list) (take size list :: res)
+        in
+            partitionTail size list [] |> reverse

--- a/test/Test/Base64.elm
+++ b/test/Test/Base64.elm
@@ -2,6 +2,7 @@ module Test.Base64 exposing (tests)
 
 import Base64
 import ElmTest exposing (Test, assertEqual, defaultTest, suite)
+import String
 
 
 encodeTest : ( String, String ) -> Test
@@ -14,12 +15,21 @@ decodeTest ( string, base64 ) =
     defaultTest (assertEqual (Result.Ok string) (Base64.decode base64))
 
 
+longDecoded =
+    String.repeat 9000 "@"
+
+
+longEncoded =
+    String.repeat 3000 "QEBA"
+
+
 examples =
     [ ( "aaa", "YWFh" )
     , ( "my updated file contents", "bXkgdXBkYXRlZCBmaWxlIGNvbnRlbnRz" )
     , ( "a", "YQ==" )
     , ( "aa", "YWE=" )
     , ( "Elm is Cool", "RWxtIGlzIENvb2w=" )
+    , ( longDecoded, longEncoded )
     ]
 
 


### PR DESCRIPTION
With longer inputs, decoding can fail on stack overflow. This rewrite allows the runtime to apply tail call optimization, thus preventing the "too much recursion" error.

Closes: #12 
