### PR TITLE
Remove output null byte checks

### DIFF
--- a/src/Base64/Decode.elm
+++ b/src/Base64/Decode.elm
@@ -28,9 +28,9 @@ validBase64Regex =
 
 stripNulls : String -> String -> String
 stripNulls input output =
-    if String.endsWith "==" input && String.endsWith "\x00\x00" output then
+    if String.endsWith "==" input then
         String.dropRight 2 output
-    else if String.endsWith "=" input && String.endsWith "\x00" output then
+    else if String.endsWith "=" input then
         String.dropRight 1 output
     else
         output


### PR DESCRIPTION
The checks are redundant if the decode implementation works correctly, and, more importantly, introduce a bug when the elm code is compiled to JS with `elm-make`. The compiled code doesn't remove the final null. Interestingly, serving from `elm-reactor` doesn't have the same problem.

I'm using elm 0.18, elm-base64 2.0.1, Chrome 62.