### PR TITLE
Support for decoding non padded Base64 strings

### DIFF
--- a/src/Base64.elm
+++ b/src/Base64.elm
@@ -1,4 +1,4 @@
-module Base64 exposing (decode, encode)
+module Base64 exposing (decode, encode, padAndDecode)
 
 {-| Library for base64 encoding and decoding.
 
@@ -11,7 +11,11 @@ when decoding from base64.
     decode "8J+RjQ=="
     --> Ok "👍"
 
-@docs encode, decode
+
+    padAndDecode "8J+RjQ"
+    --> Ok "👍"
+
+@docs encode, decode, padAndDecode
 
 -}
 
@@ -36,3 +40,18 @@ If the resulting string cannot be converted to UTF-16, this will result in an
 decode : String -> Result String String
 decode =
     Internal.decode
+
+
+{-| Decodes non padded Base64 into Elm strings.
+
+Base64 strings might be encountered in non padded form where possible trailing
+`'='` pad characters are stripped. For example JWT tokens contain non padded
+format.
+
+`padAndDecode` will first add missing `'='` padding and then use regular strict
+`decode` function with same results.
+
+-}
+padAndDecode : String -> Result String String
+padAndDecode =
+    Internal.padAndDecode

--- a/src/Base64.elm
+++ b/src/Base64.elm
@@ -1,4 +1,4 @@
-module Base64 exposing (decode, encode, padAndDecode)
+module Base64 exposing (decode, encode)
 
 {-| Library for base64 encoding and decoding.
 
@@ -15,7 +15,7 @@ when decoding from base64.
     padAndDecode "8J+RjQ"
     --> Ok "👍"
 
-@docs encode, decode, padAndDecode
+@docs encode, decode
 
 -}
 
@@ -36,22 +36,9 @@ This can result in an `Err "Invalid base64"` if the input is not valid base64.
 If the resulting string cannot be converted to UTF-16, this will result in an
 `Err "Invalid UTF-16"`.
 
+Trailing `=` characters may be omitted.
+
 -}
 decode : String -> Result String String
 decode =
     Internal.decode
-
-
-{-| Decodes non padded Base64 into Elm strings.
-
-Base64 strings might be encountered in non padded form where possible trailing
-`'='` pad characters are stripped. For example JWT tokens contain non padded
-format.
-
-`padAndDecode` will first add missing `'='` padding and then use regular strict
-`decode` function with same results.
-
--}
-padAndDecode : String -> Result String String
-padAndDecode =
-    Internal.padAndDecode

--- a/src/Base64/Decode.elm
+++ b/src/Base64/Decode.elm
@@ -1,4 +1,4 @@
-module Base64.Decode exposing (decode)
+module Base64.Decode exposing (decode, padAndDecode)
 
 import Bitwise exposing (and, or, shiftLeftBy, shiftRightZfBy)
 import Char
@@ -12,6 +12,19 @@ decode input =
         |> Result.andThen (String.foldl chomp initial >> wrapUp)
         |> Result.map (stripNulls input)
 
+padAndDecode : String -> Result String String
+padAndDecode input =
+    input |> pad |> decode
+
+pad : String -> String
+pad input =
+    case rem (String.length input) 4 of
+        3 ->
+            input ++ "="
+        2 ->
+            input ++ "=="
+        _ ->
+            input
 
 validate : String -> Result String String
 validate input =

--- a/src/Base64/Decode.elm
+++ b/src/Base64/Decode.elm
@@ -1,4 +1,4 @@
-module Base64.Decode exposing (decode, padAndDecode)
+module Base64.Decode exposing (decode)
 
 import Bitwise exposing (and, or, shiftLeftBy, shiftRightZfBy)
 import Char
@@ -6,25 +6,30 @@ import Regex exposing (Regex, regex)
 
 
 decode : String -> Result String String
-decode input =
+decode =
+    pad >> validateAndDecode
+
+
+validateAndDecode : String -> Result String String
+validateAndDecode input =
     input
         |> validate
         |> Result.andThen (String.foldl chomp initial >> wrapUp)
         |> Result.map (stripNulls input)
 
-padAndDecode : String -> Result String String
-padAndDecode input =
-    input |> pad |> decode
 
 pad : String -> String
 pad input =
     case rem (String.length input) 4 of
         3 ->
             input ++ "="
+
         2 ->
             input ++ "=="
+
         _ ->
             input
+
 
 validate : String -> Result String String
 validate input =

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -1,6 +1,6 @@
 module Tests exposing (..)
 
-import Base64 exposing (decode, encode)
+import Base64 exposing (decode, encode, padAndDecode)
 import Expect exposing (Expectation)
 import Fuzz exposing (string)
 import Test exposing (..)
@@ -17,6 +17,29 @@ cases =
     , ( "foobar", "Zm9vYmFy" )
     , ( "\n", "Cg==" )
     , ( "✓ à la mode", "4pyTIMOgIGxhIG1vZGU=" )
+    , ( "💩", "8J+SqQ==" )
+    , ( "💩💩💩", "8J+SqfCfkqnwn5Kp" )
+    , ( "Man", "TWFu" )
+    , ( String.repeat 500 "Man", String.repeat 500 "TWFu" )
+    , ( String.repeat 5000 "Man", String.repeat 5000 "TWFu" )
+    ]
+
+
+nonPaddedCases : List ( String, String )
+nonPaddedCases =
+    [ ( "", "" )
+    , ( "f", "Zg" )
+    , ( "fo", "Zm8" )
+    , ( "foo", "Zm9v" )
+    , ( "foob", "Zm9vYg" )
+    , ( "foob", "Zm9vYg==" )
+    , ( "fooba", "Zm9vYmE" )
+    , ( "foobar", "Zm9vYmFy" )
+    , ( "\n", "Cg" )
+    , ( "\n", "Cg==" )
+    , ( "✓ à la mode", "4pyTIMOgIGxhIG1vZGU" )
+    , ( "✓ à la mode", "4pyTIMOgIGxhIG1vZGU=" )
+    , ( "💩", "8J+SqQ" )
     , ( "💩", "8J+SqQ==" )
     , ( "💩💩💩", "8J+SqfCfkqnwn5Kp" )
     , ( "Man", "TWFu" )
@@ -49,6 +72,19 @@ decodeTests =
                             |> Expect.equal (Ok output)
             )
         |> describe "decode basics"
+
+
+padAndDecodeTests : Test
+padAndDecodeTests =
+    nonPaddedCases
+        |> List.map
+            (\( output, input ) ->
+                test ("Can decode '" ++ input ++ "'") <|
+                    \_ ->
+                        padAndDecode input
+                            |> Expect.equal (Ok output)
+            )
+        |> describe "decode non-padded base64"
 
 
 roundTrip : Test


### PR DESCRIPTION
Base64 strings might be encountered in non padded form where possible trailing `'='` pad characters are stripped. For example JSON Web Tokens contain non padded format.

This change will add `padAndDecode` function which will first add possibly missing `'='` padding and then use regular strict `decode` function with same results.